### PR TITLE
34 mdatarequestinprogress reseted before the connection request if analyzed

### DIFF
--- a/source/GarminSDComms.mc
+++ b/source/GarminSDComms.mc
@@ -125,7 +125,6 @@ class GarminSDComms {
   // Receive the data from the web request - should be a json string
   function onSdStatusReceive(responseCode, data) {
     var tagStr = "SDComms.onSdStatusReceive";
-    mStatusRequestInProgress = 0;
     writeLog(tagStr, "ResponseCode="+responseCode);
     if (responseCode == 200) {
       if (responseCode != lastOnSdStatusReceiveResponse) {
@@ -174,6 +173,7 @@ class GarminSDComms {
       }
     }
     lastOnSdStatusReceiveResponse = responseCode;
+    mStatusRequestInProgress = 0;
   }
 
   // Receive the response from the sendAccelData web request.
@@ -181,7 +181,6 @@ class GarminSDComms {
     var tagStr = "SDComms.onDataReceive()";
     var sendDuration = Time.now().subtract(mDataSendStartTime);
     writeLog(tagStr, "sendAccelData End - Send Duration = " + sendDuration.value());
-    mDataRequestInProgress = 0;
     if (responseCode == 200) {
       if (responseCode != lastOnReceiveResponse || data != lastOnReceiveData) {
         writeLog(tagStr, "Success - data =" + data);
@@ -217,6 +216,7 @@ class GarminSDComms {
     }
     lastOnReceiveResponse = responseCode;
     lastOnReceiveData = data;
+    mDataRequestInProgress = 0;
   }
 
   // Receive the response from the sendSettings web request.


### PR DESCRIPTION
I made sure the boolean protecting the system from being overloaded by web request includ also the response analysis tie in order to prevent the watch to be overloaded in case the phone answer quickly, faster than the watch process the answer.

Please tell me what you think.

I tested it on my watch and it seems to work ok after that. NOt sure yet if it improves anything.