### PR TITLE
52 unexpected low battery life garmin vivoactive 3

### DIFF
--- a/source/GarminSDComms.mc
+++ b/source/GarminSDComms.mc
@@ -71,6 +71,7 @@ class GarminSDComms {
       //writeLog(tagStr, "sendAccelData Start");
       var dataObj = mAccelHandler.getDataJson();
       mDataRequestInProgress = 1;
+      mDataSendStartTime = Time.now();
       Comm.makeWebRequest(
         serverUrl + "/data",
         { "dataObj" => dataObj },
@@ -82,7 +83,6 @@ class GarminSDComms {
         },
         method(:onDataReceive)
       );
-      mDataSendStartTime = Time.now();
     }
   }
 


### PR DESCRIPTION
Making sure timeout is calculated only when a request is active and not just when 5 sec passed since the last request.